### PR TITLE
Make pip-installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Try setting the `draft` YAML option to either `true` or `false` and
 then exporting this README to .html, .tex, or .pdf to see the effect it
 has on the final output.
 
+# Installation
+
+```
+> pip install "git+https://github.com/bwhelm/Pandoc-Comment-Filter.git"
+```
+This installs the command `pandoc-comments` into the `bin` directory
+of the current python installation.
+
+# Usage
+
+`pandoc --filter pandoc-comments` etc.
+
 # Syntax for markdown:
 
 ## Block Elements:

--- a/pandocCommentFilter.py
+++ b/pandocCommentFilter.py
@@ -461,6 +461,8 @@ def handle_comments(key, value, docFormat, meta):
     else:  # Not text this filter modifies....
         return
 
+def cli():
+    return toJSONFilter(handle_comments)
 
 if __name__ == "__main__":
-    toJSONFilter(handle_comments)
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ install_requires = ['pandocfilters']
 setup(
     name="Pandoc-Comment-Filter",
     version="1.0",
-    packages=find_packages(),
+    py_modules=['pandocCommentFilter'],
     install_requires=install_requires,
-    include_package_data=True,
     zip_safe=True,
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+install_requires = ['pandocfilters']
+
+setup(
+    name="Pandoc-Comment-Filter",
+    version="1.0",
+    packages=find_packages(),
+    install_requires=install_requires,
+    include_package_data=True,
+    zip_safe=True,
+    entry_points="""
+        [console_scripts]
+        pandoc-comments=pandocCommentFilter:cli
+    """
+)


### PR DESCRIPTION
I made the command `pip`-installable for ease of use by 3rd parties. I titled the exposed global alias `pandoc-comments` for parallelism with, e.g., `pandoc-citeproc` but this could be changed.

:)